### PR TITLE
fixed function name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Node module to communicate with a AVM FritzBox and FRITZ!DECT 200 (smart home ha
 ### General functions
 
 - Get the session ID (`getSessionID`)
-- Get device list as XML (`getDeviceListInfos`) >FritzOS 6.10
+- Get device list as XML (`getDeviceListInfo`) >FritzOS 6.10
 - Get temperature (`getTemperature`)
 
 ### FRITZ!DECT 200 outlet functions


### PR DESCRIPTION
I think there's a typo in the README because the function getDeviceListInfos does not exist in the code. I only found getDeviceListInfo
